### PR TITLE
Pre-process captured images for improved OCR.

### DIFF
--- a/workflow/capture.rb
+++ b/workflow/capture.rb
@@ -8,6 +8,10 @@ languages = language_override == '' ? config.get_current_languages_string : lang
 # captures screen interatively
 `/usr/sbin/screencapture -i temp-screenshot.png`
 
+# pre-process captured image to be larger and greyscale for improving tesseract results.
+# NOTE: requires ImageMagick is installed via homebrew.
+`/usr/local/bin/convert temp-screenshot.png -resize 400% -type Grayscale temp-screenshot.tif`
+
 # runs OCR on captured bitmap
 `/usr/local/bin/tesseract -l "#{languages}" temp-screenshot.png temp-ocr > /dev/null 2>&1`
 


### PR DESCRIPTION
Added the requirement that ImageMagick is installed via Homebrew. Improves Tesseract OCR quality by converting image to greyscale TIF with increased size.